### PR TITLE
Fixed echo.go

### DIFF
--- a/echo.go
+++ b/echo.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"github.com/labstack/echo"
 )
 
@@ -14,7 +15,7 @@ func initEcho() {
 		return c.String(200, "Hello, World")
 	})
 	h.Get("/:name", func(c *echo.Context) error {
-		return c.String(200, "Hello, %s", c.Param("name"))
+		return c.String(200, fmt.Sprintf("Hello, %s", c.Param("name")))
 	})
 	registerHandler("echo", h)
 }

--- a/echo.go
+++ b/echo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/labstack/echo"
 )
 


### PR DESCRIPTION
Don't work echo.go

```
$  go test -bench=.
# _/.../go-frameworks-benchmark
./echo.go:17: too many arguments in call to c.String
FAIL    _/.../go-frameworks-benchmark [build failed]
```

changed interface.
https://github.com/labstack/echo/commit/f54cdd86d0ee30939859fb8b6c8430a418f78b94
