### PR TITLE
Add chi

### DIFF
--- a/chi.go
+++ b/chi.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/pressly/chi"
+	"golang.org/x/net/context"
+)
+
+func init() {
+	calcMem("chi", initChi)
+}
+
+func initChi() {
+	h := chi.NewRouter()
+	h.Get("/", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "Hello, World")
+	})
+	h.Get("/:name", func(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		fmt.Fprintf(w, "Hello, %s", chi.URLParams(ctx)["name"])
+	})
+	registerHandler("chi", h)
+}

--- a/chi_test.go
+++ b/chi_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestChiParam(t *testing.T) {
+	req, _ := http.NewRequest("GET", "/gopher", nil)
+	c, b, h := sendRequest(getHandler("chi"), req)
+	if c != 0 && c != 200 {
+		t.Errorf("invalid status code")
+	}
+	if !strings.Contains(string(b), "gopher") {
+		t.Errorf("invalid body")
+	}
+	if h == nil || !strings.Contains(h["Content-Type"][0], "text/plain") {
+		t.Errorf("invalid header")
+	}
+}
+
+func BenchmarkChiSimple(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/", nil)
+	benchRequest(b, getHandler("chi"), req)
+}
+
+func BenchmarkChiParam(b *testing.B) {
+	req, _ := http.NewRequest("GET", "/gopher", nil)
+	benchRequest(b, getHandler("chi"), req)
+}


### PR DESCRIPTION
Add [chi](https://github.com/pressly/chi) benchmark

My results

```
$ go test -bench=.
   bone: 3360 Bytes
   chi: 1176 Bytes
   echo: 880 Bytes
   gin: 712 Bytes
   gocraft: 1600 Bytes
   goji: 40232 Bytes
   gorilla: 5512 Bytes
   http: 624 Bytes
   kami: 1160 Bytes
   martini: 82096 Bytes
   siesta: 680 Bytes
PASS
BenchmarkBoneSimple-4        2000000           630 ns/op         416 B/op          3 allocs/op
BenchmarkBoneParam-4         1000000          1873 ns/op         800 B/op          7 allocs/op
BenchmarkChiSimple-4         1000000          1141 ns/op         560 B/op          8 allocs/op
BenchmarkChiParam-4          1000000          1799 ns/op         880 B/op         11 allocs/op
BenchmarkEchoSimple-4        2000000           667 ns/op         432 B/op          4 allocs/op
BenchmarkEchoParam-4         1000000          1048 ns/op         464 B/op          6 allocs/op
BenchmarkGinSimple-4         2000000           646 ns/op         416 B/op          3 allocs/op
BenchmarkGinParam-4          2000000           819 ns/op         416 B/op          3 allocs/op
BenchmarkGocraftSimple-4     1000000          1413 ns/op         696 B/op          8 allocs/op
BenchmarkGocraftParam-4      1000000          2310 ns/op        1064 B/op         12 allocs/op
BenchmarkGojiSimple-4        2000000           789 ns/op         416 B/op          3 allocs/op
BenchmarkGojiParam-4         1000000          1774 ns/op         768 B/op          6 allocs/op
BenchmarkGorillaSimple-4     1000000          2575 ns/op         896 B/op         11 allocs/op
BenchmarkGorillaParam-4       300000          4735 ns/op        1264 B/op         15 allocs/op
BenchmarkHttpSimple-4        2000000           966 ns/op         416 B/op          3 allocs/op
BenchmarkHttpParam-4          500000          2193 ns/op         848 B/op          7 allocs/op
BenchmarkKamiSimple-4        2000000           656 ns/op         416 B/op          3 allocs/op
BenchmarkKamiParam-4         1000000          1312 ns/op         576 B/op          9 allocs/op
BenchmarkMartiniSimple-4      200000          6054 ns/op        1312 B/op         17 allocs/op
BenchmarkMartiniParam-4       200000          8419 ns/op        1729 B/op         22 allocs/op
BenchmarkSiestaSimple-4      1000000          1499 ns/op         904 B/op         11 allocs/op
BenchmarkSiestaParam-4        300000          4223 ns/op        2056 B/op         24 allocs/op
ok      _/.../go-frameworks-benchmark   39.585s
```
